### PR TITLE
Provides an RSpec 3 compatible formatter.

### DIFF
--- a/lib/fivemat.rb
+++ b/lib/fivemat.rb
@@ -4,12 +4,36 @@ module Fivemat
   autoload :Cucumber, 'fivemat/cucumber'
   autoload :MiniTest, 'fivemat/minitest/unit'
   autoload :RSpec, 'fivemat/rspec'
+  autoload :RSpec3, 'fivemat/rspec3'
   autoload :Spec, 'fivemat/spec'
+
+  def rspec3?
+    defined?(::RSpec) && ::RSpec::Core::Version::STRING >= '3.0.0'
+  end
+  module_function :rspec3?
+
+  if rspec3?
+    # This needs to be run before `.new` is called, so putting it inside the
+    # autoloaded rspec3 file will not work.
+    ::RSpec::Core::Formatters.register self,
+      :example_passed,
+      :example_pending,
+      :example_failed,
+      :example_group_started,
+      :example_group_finished,
+      :dump_pending_fixed,
+      :dump_summary
+  end
 
   def self.new(*args)
     case args.size
     when 0 then MiniTest::Unit
-    when 1 then RSpec
+    when 1 then
+      if rspec3?
+        RSpec3
+      else
+        RSpec
+      end
     when 2 then Spec
     when 3 then Cucumber
     else

--- a/lib/fivemat/rspec3.rb
+++ b/lib/fivemat/rspec3.rb
@@ -1,0 +1,74 @@
+require 'rspec/core/formatters/base_text_formatter'
+
+module Fivemat
+  class RSpec3 < ::RSpec::Core::Formatters::BaseTextFormatter
+    include ElapsedTime
+
+    # See fivemat.rb for formatter registration.
+
+    def initialize(output)
+      super(output)
+      @group_level = 0
+      @index_offset = 0
+      @cumulative_failed_examples = []
+      @failed_examples = []
+    end
+
+    def example_passed(notification)
+      output.print success_color('.')
+    end
+
+    def example_pending(notification)
+      super
+      output.print pending_color('*')
+    end
+
+    def example_failed(event)
+      super
+      output.print failure_color('F')
+    end
+
+    def example_group_started(event)
+      if @group_level.zero?
+        output.print "#{event.group.description} "
+        @failure_output = []
+        @start_time = Time.now
+      end
+      @group_level += 1
+    end
+
+    def example_group_finished(event)
+      @group_level -= 1
+      if @group_level.zero?
+        print_elapsed_time output, @start_time
+        output.puts
+
+        failed_examples.each_with_index do |example, index|
+          if pending_fixed?(example)
+            dump_pending_fixed(example, @index_offset + index)
+          else
+            dump_failure(example, @index_offset + index)
+          end
+          dump_backtrace(example)
+        end
+        @index_offset += failed_examples.size
+        @cumulative_failed_examples += failed_examples
+        failed_examples.clear
+      end
+    end
+
+    def pending_fixed?(example)
+      example.execution_result.pending_fixed?
+    end
+
+    def dump_pending_fixed(example, index)
+      output.puts "#{short_padding}#{index.next}) #{example.full_description} FIXED"
+      output.puts fixed_color("#{long_padding}Expected pending '#{example.execution_result.pending_message}' to fail. No Error was raised.")
+    end
+
+    def dump_summary(*args)
+      @failed_examples = @cumulative_failed_examples
+      super
+    end
+  end
+end


### PR DESCRIPTION
- Opted to keep this separate rather than try to remove duplication
  with the RSpec 2 formatter. It's just subtlely different enough that
  trying to DRY this up would make the code harder to understand.
  little gain. It would also risk introducing bugs into the old
  formatter. Assuming this code is pretty much stable now and that any
  new features or bug fixes would apply only to this new version.
- ProgressFormatter is private, so now inherits from BaseTextFormatter.
  (Having a discussion with core team about whether it should be public.)
- Simplified `pending_fixed?` with new consistent API.
- Use `fixed_color` rather than removed `blue`.
- Use accessor on `execution_result` rather than treating it as a hash.

Fixes #13.
Fixes #14.

@tpope @JonRowe
