### PR TITLE
Gracefully handle failures in Rspec 3 formatter.

### DIFF
--- a/lib/fivemat/rspec3.rb
+++ b/lib/fivemat/rspec3.rb
@@ -58,12 +58,12 @@ module Fivemat
     end
 
     def pending_fixed?(example)
-      example.execution_result.pending_fixed?
+      example.execution_result[:pending_fixed]
     end
 
     def dump_pending_fixed(example, index)
       output.puts "#{short_padding}#{index.next}) #{example.full_description} FIXED"
-      output.puts fixed_color("#{long_padding}Expected pending '#{example.execution_result.pending_message}' to fail. No Error was raised.")
+      output.puts fixed_color("#{long_padding}Expected pending '#{example.description}' to fail. No Error was raised.")
     end
 
     def dump_summary(*args)


### PR DESCRIPTION
fixes tpope/fivemat#19

[Waiting to hear back from Myron](https://twitter.com/BRMatt/status/459105545480572928) as to whether this is the correct approach, but it seems to fix things for me.

Using the example test case from tpop/fivemat#19:

```
a pending test that fails *                                               
a pending test that passes F                                              
  1) a pending test that passes this fails! FIXED                         
     Expected pending 'this fails!' to fail. No Error was raised.         
     # ./test_spec.rb:11:in `block in <top (required)>'                   
     # ./test_spec.rb:10:in `<top (required)>'                            
a failing test F                                                          
  2) a failing test should not cause fivemat to crash                     
     Failure/Error: raise "Hello"                                         
     RuntimeError:                                                        
       Hello                                                              
     # ./test_spec.rb:18:in `block (2 levels) in <top (required)>'        

Finished in 0.00937 seconds                                               
3 examples, 2 failures, 1 pending                                         

Failed examples:                                                          

rspec ./test_spec.rb:11 # a pending test that passes this fails!          
rspec ./test_spec.rb:17 # a failing test should not cause fivemat to crash
```
