### PR TITLE
Handle RSpec’s `message` event.

### DIFF
--- a/lib/fivemat.rb
+++ b/lib/fivemat.rb
@@ -22,7 +22,8 @@ module Fivemat
       :example_group_started,
       :example_group_finished,
       :dump_summary,
-      :seed
+      :seed,
+      :message
   end
 
   def self.new(*args)

--- a/lib/fivemat/rspec3.rb
+++ b/lib/fivemat/rspec3.rb
@@ -62,5 +62,9 @@ module Fivemat
       return unless notification.seed_used?
       output.puts notification.fully_formatted
     end
+
+    def message(notification)
+      output.puts notification.message
+    end
   end
 end


### PR DESCRIPTION
RSpec uses this to notify the formatter about things like early aborts, filtering options, etc.