### PR TITLE
Fixed issue with RSpec 2.99.2

### DIFF
--- a/lib/fivemat/rspec.rb
+++ b/lib/fivemat/rspec.rb
@@ -43,6 +43,9 @@ module Fivemat
     def pending_fixed?(example)
       if example.execution_result[:exception].respond_to?(:pending_fixed?)
         example.execution_result[:exception].pending_fixed?
+      elsif defined?(::RSpec::Core::Pending::PendingExampleFixedError)
+        # RSpec 2.99.2 compatibility
+        ::RSpec::Core::Pending::PendingExampleFixedError == example.execution_result[:exception]
       else
         ::RSpec::Core::PendingExampleFixedError === example.execution_result[:exception]
       end


### PR DESCRIPTION
RSpec 2.99 is a different monster. It has some warnings to help you migrate to 3.x but also behave in a way that fails with Fivemat.

I currently cannot migrate to 3.x so I need this fix to workout the problem.

Here is the stacktrace I got before the fix:
```
/opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/formatters/deprecation_formatter.rb:187:in `puts': RSpec::Core::PendingExampleFixedError is deprecated. Use RSpec::Core::Pending::PendingExampleFixedError instead. Called from /Users/brodock/src/fivemat/lib/fivemat/rspec.rb:47:in `pending_fixed?'. (RSpec::Core::DeprecationError)
	from /opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/formatters/deprecation_formatter.rb:124:in `print_deprecation_message'
	from /opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/formatters/deprecation_formatter.rb:32:in `deprecation'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:130:in `block in notify'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:129:in `each'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:129:in `notify'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:101:in `deprecation'
	from /opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/deprecation.rb:8:in `deprecate'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/pending.rb:161:in `const_missing'
	from /Users/brodock/src/fivemat/lib/fivemat/rspec.rb:47:in `pending_fixed?'
	from /opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/formatters/base_text_formatter.rb:24:in `block in dump_failures'
	from /opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/formatters/base_text_formatter.rb:22:in `each'
	from /opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/formatters/base_text_formatter.rb:22:in `each_with_index'
	from /opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/formatters/base_text_formatter.rb:22:in `dump_failures'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:130:in `block in notify'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:129:in `each'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:129:in `notify'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:109:in `finish'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:60:in `ensure in report'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/reporter.rb:60:in `report'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:21:in `run'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
	from /opt/rubies/2.2.2/lib/ruby/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'
	from /opt/boxen/rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /opt/boxen/rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from -e:1:in `<main>'
```