### PR TITLE
Fix Fivemat initialization with Cucumber 2

### DIFF
--- a/lib/fivemat.rb
+++ b/lib/fivemat.rb
@@ -26,6 +26,22 @@ module Fivemat
       :message
   end
 
+  def cucumber2?
+    defined?(::Cucumber) && ::Cucumber::VERSION >= '2.0.0'
+  end
+  module_function :cucumber2?
+
+  if cucumber2?
+    def self.instance_method(symbol)
+      case symbol
+      when :initialize
+        Cucumber.instance_method(symbol)
+      else
+        super
+      end
+    end
+  end
+
   def self.new(*args)
     case args.size
     when 0 then MiniTest::Unit


### PR DESCRIPTION
Cucumber 2.x has the concept of legacy formatters and modern formatters. It checks formatters for the arity of the #initialize method to determine whether the formatter is legacy or modern. Fivemat performs a bit of trickery with a module .new method, meaning there is nothing to check the arity on.

This hacks around this bit of neepery by checking if Cucumber 2.x is loaded and overriding the #instance_method method to return the instance method of Fivemat::Cucumber.
