### PR TITLE
Fix instance variable @class not initialized warning

### DIFF
--- a/lib/minitest/fivemat_plugin.rb
+++ b/lib/minitest/fivemat_plugin.rb
@@ -5,7 +5,7 @@ module Minitest
     include ElapsedTime
 
     def record(result)
-      if @class != result.class
+      if defined?(@class) && @class != result.class
         if @class
           print_elapsed_time(io, @class_start_time)
           io.print "\n"
@@ -18,7 +18,7 @@ module Minitest
 
     def report
       super
-      print_elapsed_time(io, @class_start_time) if @class_start_time
+      print_elapsed_time(io, @class_start_time) if defined? @class_start_time
     end
   end
 


### PR DESCRIPTION
I found this while running tests:

```
# Running:

/Users/Juan/.gem/ruby/2.3.1/gems/fivemat-1.3.2/lib/minitest/fivemat_plugin.rb:8: warning: instance variable @class not initialized
/Users/Juan/.gem/ruby/2.3.1/gems/fivemat-1.3.2/lib/minitest/fivemat_plugin.rb:9: warning: instance variable @class not initialized
```

This Pull Request fixes this.
