### PR TITLE
Support Cucumber 2

### DIFF
--- a/lib/fivemat.rb
+++ b/lib/fivemat.rb
@@ -7,6 +7,17 @@ module Fivemat
   autoload :RSpec3, 'fivemat/rspec3'
   autoload :Spec, 'fivemat/spec'
 
+  def cucumber2?
+    defined?(::Cucumber) && ::Cucumber::VERSION >= '2.0.0'
+  end
+  module_function :cucumber2?
+
+  if cucumber2?
+    # Cucumber 2 detects the formatter API based on initialize arity
+    def initialize(runtime, path_or_io, options)
+    end
+  end
+
   def rspec3?
     defined?(::RSpec::Core) && ::RSpec::Core::Version::STRING >= '3.0.0'
   end

--- a/lib/fivemat/cucumber.rb
+++ b/lib/fivemat/cucumber.rb
@@ -26,7 +26,7 @@ module Fivemat
 
     def exception(exception, status)
       @exceptions << [exception, status]
-      super
+      super if defined?(super)
     end
 
     def after_features(features)
@@ -34,6 +34,9 @@ module Fivemat
       print_stats(features, @options)
       print_snippets(@options)
       print_passing_wip(@options)
+    end
+
+    def done
     end
   end
 end


### PR DESCRIPTION
Tested with Cucumber 1.3.20 and 2.4.0.

* The `initialize` issue is covered extensively in #27
* [In v2.0.1](https://github.com/cucumber/cucumber-ruby/commit/618179cba48a7017568b97a98bfb8ade82eb1ff9) the Progress formatter was changed to remove the `exception` method and moved the summary work to the `done` method.