### PR TITLE
Remove conditional definition to support preloaders, like spring

### DIFF
--- a/lib/fivemat.rb
+++ b/lib/fivemat.rb
@@ -7,15 +7,8 @@ module Fivemat
   autoload :RSpec3, 'fivemat/rspec3'
   autoload :Spec, 'fivemat/spec'
 
-  def cucumber2?
-    defined?(::Cucumber) && ::Cucumber::VERSION >= '2.0.0'
-  end
-  module_function :cucumber2?
-
-  if cucumber2?
-    # Cucumber 2 detects the formatter API based on initialize arity
-    def initialize(runtime, path_or_io, options)
-    end
+  # Cucumber 2 detects the formatter API based on initialize arity
+  def initialize(runtime, path_or_io, options)
   end
 
   def rspec3?


### PR DESCRIPTION
I've run into the problem that when a tool like Spring has cached loading of Fivemat for RSpec or MiniTest, that when it tries to use it for Cucumber that it fails because of the conditional definition of `initialize`. Simplest answer is just remove the condition.

```
$ cucumber
Running via Spring preloader in process 25468
undefined method `initialize' for module `Fivemat'
Did you mean?  initialize (NameError)
gems/cucumber-2.99.0/lib/cucumber/runtime.rb:209:in `instance_method'
gems/cucumber-2.99.0/lib/cucumber/runtime.rb:209:in `legacy_formatter?'
gems/cucumber-2.99.0/lib/cucumber/runtime.rb:196:in `create_formatter'
gems/cucumber-2.99.0/lib/cucumber/runtime.rb:191:in `block in formatters'
gems/cucumber-2.99.0/lib/cucumber/configuration.rb:180:in `block in formatter_factories'
gems/cucumber-2.99.0/lib/cucumber/configuration.rb:175:in `map'
gems/cucumber-2.99.0/lib/cucumber/configuration.rb:175:in `formatter_factories'
gems/cucumber-2.99.0/lib/cucumber/runtime.rb:190:in `formatters'
gems/cucumber-2.99.0/lib/cucumber/runtime.rb:172:in `report'
gems/cucumber-2.99.0/lib/cucumber/runtime.rb:64:in `run!'
gems/cucumber-2.99.0/lib/cucumber/cli/main.rb:32:in `execute!'
gems/cucumber-2.99.0/bin/cucumber:8:in `<top (required)>'
gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `block in load'
gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
bin/cucumber:8:in `<top (required)>'
gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `block in load'
gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
ruby-2.3.5/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
ruby-2.3.5/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
-e:1:in `<main>'
```