### PR TITLE
Fix reporting for Minitest 5+

### DIFF
--- a/lib/minitest/fivemat_plugin.rb
+++ b/lib/minitest/fivemat_plugin.rb
@@ -4,13 +4,18 @@ module Minitest
   class FivematReporter < Reporter
     include ElapsedTime
 
+    def initialize(*args)
+      super
+      @class = nil
+    end
+
     def record(result)
-      if defined?(@class) && @class != result.class
+      if @class != result.klass
         if @class
           print_elapsed_time(io, @class_start_time)
           io.print "\n"
         end
-        @class = result.class
+        @class = result.klass
         @class_start_time = Time.now
         io.print "#@class "
       end


### PR DESCRIPTION
The fix given in 191bef2b3caf4df5c2fab0396dedfc24152c7b8e actually broke the reporter entirely; because `@class` will not be defined initially, it never will be because the body of the `if` statement will never be entered. I can thing of two fixes. The smallest-diff fix would be to change to

```ruby
@class = nil unless defined?(@class)
if @class != result.klass
```

However, it seems more in the spirit of OO to do one-time initialisation of variables in the constructor.

This commit also updates the reporter to use the accessor `Result#klass`, rather than `#class`.